### PR TITLE
remove the tabs permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,6 @@
   "description": "__MSG_extDesc__",
   "permissions": [
     "contextMenus",
-    "tabs",
     "storage"
   ],
   "host_permissions": [


### PR DESCRIPTION
@nsa-yoda this should get the extension back into the store. afaict, the tabs permission isn't needed to use this api